### PR TITLE
remove links from description tag (#22)

### DIFF
--- a/blacklist-updater.php
+++ b/blacklist-updater.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Block List Updater
- * Description: Automatic updating of the <a href='options-discussion.php'>comment block list</a> in WordPress with antispam keys from <a href='https://github.com/splorp/wordpress-comment-blacklist' target='_blank'>GitHub</a>.
+ * Description: Automatic updating of the comment block list in WordPress with antispam keys from "Comment Blocklist for WordPress" (on GitHub).
  * Author:      pluginkollektiv
  * Author URI:  https://pluginkollektiv.org
  * Plugin URI:  https://wordpress.org/plugins/blacklist-updater/


### PR DESCRIPTION
Hyperlinks in the "description" tag of the plugin header are not rendered, so let's remove them and add the GitHub project name instead.

resolves #22