### PR TITLE
ci: add workflow to run wp plugin checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Directories
 /.github export-ignore
 /.wordpress-org export-ignore
+/dist export-ignore
 /vendor export-ignore
 
 # Files

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,22 @@
+name: Plugin check
+on:
+  push:
+    branches: [ 'master', 'release/*' ]
+  pull_request:
+    branches: [ 'master' ]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Package plugin
+        run: |
+          mkdir -p dist/blacklist-updater
+          git archive HEAD | tar x --directory=dist/blacklist-updater
+
+      - name: Check WP plugin
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: dist/blacklist-updater

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
+dist/
 vendor/


### PR DESCRIPTION
The only error is a complaint about the tested WP version being too old.

> Error: Tested up to: 6.6 < 6.8. The "Tested up to" value in your plugin is not set to the current version of WordPress. This means your plugin will not show up in searches, as we require plugins to be compatible and documented as tested up to the most recent version of WordPress.

That's correct and is subject of a different changeset.

And some warnings

> Warning: error_log() found. Debug code should not normally be used in production.

see #31

> Warning: One or more tags were ignored. Please limit your plugin to 5 tags.

see #32 

----

So the action itself does what it's expected to do.