### PR TITLE
change arg name in autoloader function and enable PHPCS warning

### DIFF
--- a/blacklist-updater.php
+++ b/blacklist-updater.php
@@ -94,14 +94,14 @@ spl_autoload_register( 'blacklist_updater_autoload' );
 /**
  * Plugin autoloader.
  *
- * @param string $class The classname.
+ * @param string $class_name The classname.
  */
-function blacklist_updater_autoload( $class ) {
-	if ( in_array( $class, array( 'Blacklist_Updater' ) ) ) {
+function blacklist_updater_autoload( $class_name ) {
+	if ( in_array( $class_name, array( 'Blacklist_Updater' ), true ) ) {
 		require_once sprintf(
 			'%s/inc/class-%s.php',
 			dirname( __FILE__ ),
-			strtolower( str_replace( '_', '-', $class ) )
+			strtolower( str_replace( '_', '-', $class_name ) )
 		);
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,7 @@
 <ruleset>
 	<description>Sniffs for the coding standards of the plugin</description>
 
-	<arg value="psvn"/>
+	<arg value="psv"/>
 	<arg name="colors"/>
 
 	<!-- Files to sniff -->


### PR DESCRIPTION
Use $class_name to avoid the reserved keyword "class" and add strict comparison for strings. With these warnings fixed we can enable warnings in PHPCS and keep our code clean.

Warnings are also enabled in the plugin-check action. We should keep both configs in-sync so we see our issues earlier during development.