### PR TITLE
Fix: replace broken ETag regex with sanitize_text_field()

### DIFF
--- a/inc/class-blacklist-updater.php
+++ b/inc/class-blacklist-updater.php
@@ -145,14 +145,7 @@ class Blacklist_Updater {
 		self::debug_log( 'Comment block list successfully updated' );
 
 		/* Get & validate Etag */
-		$etag = preg_replace(
-			'/^[a-f0-9"]$/',
-			'',
-			wp_remote_retrieve_header(
-				$response,
-				'etag'
-			)
-		);
+		$etag = sanitize_text_field( wp_remote_retrieve_header( $response, 'etag' ) );
 
 		/* Update options */
 		update_site_option(

--- a/inc/class-blacklist-updater.php
+++ b/inc/class-blacklist-updater.php
@@ -145,7 +145,7 @@ class Blacklist_Updater {
 		self::debug_log( 'Comment block list successfully updated' );
 
 		/* Get & validate Etag */
-		$etag = sanitize_text_field( wp_remote_retrieve_header( $response, 'etag' ) );
+		$etag = preg_replace( '/[^a-f0-9"]/i', '', wp_remote_retrieve_header( $response, 'etag' ) );
 
 		/* Update options */
 		update_site_option(


### PR DESCRIPTION
Hey folks,

The regex used to sanitize the ETag header value — `/^[a-f0-9"]$/` — anchors to a single character, so it never matches a real ETag string and passes every value through unfiltered. Replace it with `sanitize_text_field()`, which is the standard WP approach for sanitizing arbitrary string input.

One-line change.

(full disclosure, I used AI help with the testing and tweaks - Christopher)
